### PR TITLE
fix for numeric params needed with openshift v4

### DIFF
--- a/openshift/deployments/lazar/lazar.yaml
+++ b/openshift/deployments/lazar/lazar.yaml
@@ -164,7 +164,7 @@ objects:
     ports:
     - name: lazar
       protocol: TCP
-      port: ${LAZAR_SERVICE_PORT}
+      port: ${{LAZAR_SERVICE_PORT}}
       targetPort: 8088
       nodePort: 0
     selector:


### PR DESCRIPTION
Denis, this change seems to be needed to allow the template to work with openshift v4.
The double curly brace syntax tells the parameter to be treated as JSON (https://docs.openshift.com/container-platform/3.11/dev_guide/templates.html#writing-parameters). Without this the number ends up inside double quotes and this does not work with v4 (though its OK, but technically not correct) with v3.